### PR TITLE
Fix esp32 build

### DIFF
--- a/builder/esp32.py
+++ b/builder/esp32.py
@@ -8,7 +8,7 @@ from . import update_mphalport as _update_mphalport
 from . import (
     read_file,
     write_file,
-    copy_updated_files,
+    copy_micropy_updates,
     revert_files,
     scrub_build_folder
 )
@@ -125,7 +125,7 @@ class Partition:
             )
 
         if not os.path.exists(f'{SCRIPT_DIR}/build'):
-            os.mkdir(f'{SCRIPT_DIR}/build')
+            os.makedirs(f'{SCRIPT_DIR}/build')
 
         with open(self.save_file_path, 'w') as f:
             f.write(PARTITION_HEADER)
@@ -1140,7 +1140,7 @@ def compile(*args):  # NOQA
     update_mpconfigboard()
     update_mpconfigport()
 
-    copy_updated_files('esp32')
+    copy_micropy_updates('esp32')
 
     try:
         cmd_ = compile_cmd[:]

--- a/builder/esp32.py
+++ b/builder/esp32.py
@@ -125,7 +125,7 @@ class Partition:
             )
 
         if not os.path.exists(f'{SCRIPT_DIR}/build'):
-            os.makedirs(f'{SCRIPT_DIR}/build')
+            os.mkdir(f'{SCRIPT_DIR}/build')
 
         with open(self.save_file_path, 'w') as f:
             f.write(PARTITION_HEADER)
@@ -850,7 +850,7 @@ MAIN_PATH = 'lib/micropython/ports/esp32/main.c'
 
 
 if not os.path.exists('micropy_updates/originals/esp32'):
-    os.mkdir('micropy_updates/originals/esp32')
+    os.makedirs('micropy_updates/originals/esp32')
 
 
 def update_mpthreadport():

--- a/builder/macOS.py
+++ b/builder/macOS.py
@@ -19,7 +19,7 @@ from . import unix
 unix.REAL_PORT = 'macOS'
 
 if not os.path.exists('micropy_updates/originals/macOS'):
-    os.mkdir('micropy_updates/originals/macOS')
+    os.makedirs('micropy_updates/originals/macOS')
 
 
 def parse_args(extra_args, lv_cflags, board):

--- a/builder/raspberry_pi.py
+++ b/builder/raspberry_pi.py
@@ -17,7 +17,7 @@ from . import unix
 
 
 if not os.path.exists('micropy_updates/originals/raspberry_pi'):
-    os.mkdir('micropy_updates/originals/raspberry_pi')
+    os.makedirs('micropy_updates/originals/raspberry_pi')
 
 
 unix.REAL_PORT = 'raspberry_pi'

--- a/builder/unix.py
+++ b/builder/unix.py
@@ -211,7 +211,7 @@ def submodules():
 
 
 if not os.path.exists('micropy_updates/originals/unix'):
-    os.mkdir('micropy_updates/originals/unix')
+    os.makedirs('micropy_updates/originals/unix')
 
 
 UNIX_MPHAL_PATH = 'lib/micropython/ports/unix/unix_mphal.c'


### PR DESCRIPTION
1. In the builder, copy_updated_files was renamed to copy_micropy_updates but the change was not propagated to esp32.py
2. Various builders auto-create the directory micropy_updates/originals/esp32 using os.mkdir(), which fails if the intermediate directory 'originals' does not exist.  os.makedirs() will create the entire path.