### PR TITLE
Added build requirement for libusb-1.0-0-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Compiling for ESP32
     * cmake
     * ninja-build
     * python
+    * libusb-1.0-0-dev
     
   * macOS
     * `xcode-select -–install`


### PR DESCRIPTION
I tried compiling lvgl_micropython in a GitHub codespace (Ubuntu) and it failed.  The underlying problem was that libusb-1.0-0-dev was not installed, and the ESP-IDF export.sh errored out, causing a host of downstream problems due to paths not being set correctly