### PR TITLE
Resolve issue causing second buffer not to get created

### DIFF
--- a/ext_mod/lcd_bus/lcd_types.c
+++ b/ext_mod/lcd_bus/lcd_types.c
@@ -197,6 +197,7 @@ void rgb565_byte_swap(void *buf, uint32_t buf_size_px)
 
             if (self->view1 == NULL) {
                 self->view1 = view;
+                self->buffer_flags = caps;
             } else if (self->buffer_flags != caps) {
                 mp_raise_msg(&mp_type_MemoryError, MP_ERROR_TEXT("allocation flags must be the same for both buffers"));
                 return mp_const_none;


### PR DESCRIPTION
This is a fix for an issue caused by allocating 2 buffers in a row that seems to cause this error: `MemoryError: allocation flags must be the same for both buffers`

Reproduction code:
```py
fb1 = display_bus.allocate_framebuffer(sz, lcd_bus.MEMORY_SPIRAM)
fb2 = display_bus.allocate_framebuffer(sz, lcd_bus.MEMORY_SPIRAM)
```