### PR TITLE
Update to correctly handle SPI for C6

### DIFF
--- a/micropy_updates/esp32/machine_hw_spi.c
+++ b/micropy_updates/esp32/machine_hw_spi.c
@@ -563,7 +563,7 @@ void mp_machine_hw_spi_bus_initilize(mp_machine_hw_spi_bus_obj_t *bus)
 
     esp_err_t ret;
 
-#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3
+#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
     ret = spi_bus_initialize((spi_host_device_t)bus->host, &buscfg, SPI_DMA_CH_AUTO);
 #else
     if (bus->host == SPI2_HOST) {


### PR DESCRIPTION
Small change to allow SPI to correctly initialise on ESP32-C6.