### PR TITLE
prevent build issues with using --enable-jtag-repl=y

### DIFF
--- a/builder/esp32.py
+++ b/builder/esp32.py
@@ -1120,7 +1120,8 @@ def update_mpconfigport():
                 '#ifdef MICROPY_HW_ESP_USB_SERIAL_JTAG',
                 '#undef MICROPY_HW_ESP_USB_SERIAL_JTAG',
                 '#endif',
-                f'#define MICROPY_HW_ESP_USB_SERIAL_JTAG  ({int(enable_jtag_repl.lower() == "y")})'
+                f'#define MICROPY_HW_ESP_USB_SERIAL_JTAG  ({int(enable_jtag_repl.lower() == "y")})',
+                '#define USB_SERIAL_JTAG_PACKET_SZ_BYTES 	(64)'
             ])
 
         repl_data.extend([


### PR DESCRIPTION
Hi Kevin, I've noticed that at least the S3 and C6 series are hitting the error raised in https://github.com/lvgl-micropython/lvgl_micropython/issues/236 when enabling the JTAG REPL and I have been manually editing mpconfigboard.h for each target. 

This PR ensures USB_SERIAL_JTAG_PACKET_SZ_BYTES is defined during the build when enable-jtag-repl=y.