### PR TITLE
Add directory support to fs_driver

### DIFF
--- a/api_drivers/py_api_drivers/fs_driver.py
+++ b/api_drivers/py_api_drivers/fs_driver.py
@@ -74,6 +74,41 @@ def _fs_write_cb(drv, fs_file, buf, btw, bw):
 
     return lv.FS_RES.OK
 
+def _fs_dir_open_cb(drv, path):
+    #print(f"_fs_dir_open_cb for path '{path}'")
+    try:
+        import os # for ilistdir()
+        return {'iterator' : os.ilistdir(path)}
+    except Exception as e:
+        print(f"_fs_dir_open_cb exception: {e}")
+        return None
+
+def _fs_dir_read_cb(drv, lv_fs_dir_t, buf, btr):
+    try:
+        iterator = lv_fs_dir_t.__cast__()['iterator']
+        nextfile = iterator.__next__()
+        #print(f"nextfile: {nextfile}")
+        filename = nextfile[0]
+        entry_type = nextfile[1]  # Type field
+        if entry_type == 0x4000:
+            #print(f"{filename} is a directory")
+            filename = f"/{filename}"
+        # Convert filename to bytes with null terminator
+        tmp_data_bytes = filename.encode() + b'\x00'
+        buf.__dereference__(btr)[0:len(tmp_data_bytes)] = tmp_data_bytes
+        return lv.FS_RES.OK
+    except StopIteration:
+        # Clear buffer and return FS_ERR when iteration ends
+        buf.__dereference__(btr)[0:1] = b'\x00'  # Empty string (null byte)
+        return lv.FS_RES.NOT_EX  # Next entry "does not exist"
+    except Exception as e:
+        print(f"_fs_dir_read_cb exception: {e}")
+        return lv.FS_RES.UNKNOWN
+
+def _fs_dir_close_cb(drv, lv_fs_dir_t):
+    #print(f"_fs_dir_close_cb called")
+    # No need to cleanup the iterator so nothing to do
+    return lv.FS_RES.OK
 
 def fs_register(fs_drv, letter, cache_size=500):
 
@@ -85,6 +120,9 @@ def fs_register(fs_drv, letter, cache_size=500):
     fs_drv.seek_cb = _fs_seek_cb
     fs_drv.tell_cb = _fs_tell_cb
     fs_drv.close_cb = _fs_close_cb
+    fs_drv.dir_open_cb = _fs_dir_open_cb
+    fs_drv.dir_read_cb = _fs_dir_read_cb
+    #fs_drv.dir_close_cb = _fs_dir_close_cb
 
     if cache_size >= 0:
         fs_drv.cache_size = cache_size


### PR DESCRIPTION
Support directory operations (dir_open_cb, dir_read_cb, dir_close_cb) in fs_driver.py so that the file_explorer widget, when using fs_driver, is able to browse the filesystem.

I validated this on the unix and esp32 targets with:

```
import fs_driver
fs_drv = lv.fs_drv_t()
fs_driver.fs_register(fs_drv, 'M')
file_explorer = lv.file_explorer(lv.screen_active())
file_explorer.explorer_open_dir('M:/')
def file_explorer_event_cb(event):
    path = file_explorer.explorer_get_current_path()
    file = file_explorer.explorer_get_selected_file_name()
    print(f"Selected: {path}{file}")
file_explorer.add_event_cb(file_explorer_event_cb, lv.EVENT.VALUE_CHANGED, None)
```

If you get a UnicodeError, that's not due to this code but the binding code generator and how it handles `char *` vs `void *` arguments. See [this discussion](https://github.com/lvgl-micropython/lvgl_micropython/issues/398).