### PR TITLE
python3-venv required on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ To compile you will need Python >= 3.10 for for all build types.
     * cmake
     * ninja-build
     * python
+    * python3-venv
     * libusb-1.0-0-dev
     
   * macOS


### PR DESCRIPTION
Build fails on a fresh debian 12 if python3-venv is not installed