### PR TITLE
Fix issue #351: task handler's remove_event_cb() iterator error

### DIFF
--- a/api_drivers/common_api_drivers/frozen/other/task_handler.py
+++ b/api_drivers/common_api_drivers/frozen/other/task_handler.py
@@ -82,9 +82,9 @@ class TaskHandler(object):
             self._callbacks.append((callback, event, user_data))
 
     def remove_event_cb(self, callback):
-        for i, obj in self._callbacks:
-            if obj[0] == callback:
-                self._callbacks.remove(obj)
+        for (cb, evt, data) in self._callbacks:
+            if cb == callback:
+                self._callbacks.remove((cb,evt,data))
                 break
 
     def deinit(self):


### PR DESCRIPTION
Fix task handler's remove_event_cb() not iterating properly and giving an error.

You rock!

