### PR TITLE
fs_driver.py: fix _fs_dir_open_cb for VfsFat

### DIFF
--- a/api_drivers/py_api_drivers/fs_driver.py
+++ b/api_drivers/py_api_drivers/fs_driver.py
@@ -78,9 +78,11 @@ def _fs_dir_open_cb(drv, path):
     #print(f"_fs_dir_open_cb for path '{path}'")
     try:
         import os # for ilistdir()
+        if path != "/":
+            path = path.rstrip('/') # LittleFS handles trailing flashes fine, but vfs.VfsFat returns an [Errno 22] EINVAL
         return {'iterator' : os.ilistdir(path)}
     except Exception as e:
-        print(f"_fs_dir_open_cb exception: {e}")
+        print(f"_fs_dir_open_cb exception for path {path}: {e}")
         return None
 
 def _fs_dir_read_cb(drv, lv_fs_dir_t, buf, btr):


### PR DESCRIPTION
While testing with an SD card that has a FAT filesystem on it, I noticed that, unlike LittleFS, VfsFat returns an [Errno 22] EINVAL when a directory has a trailing slash.

This fix removes the trailing slash, except for the root directory.