### PR TITLE
fix MIPI DSI driver

### DIFF
--- a/ext_mod/lcd_bus/esp32_include/dsi_bus.h
+++ b/ext_mod/lcd_bus/esp32_include/dsi_bus.h
@@ -23,6 +23,7 @@
         #include "esp_lcd_panel_io.h"
         #include "esp_lcd_mipi_dsi.h"
 
+        #define DPI_PANEL_MAX_FB_NUM 3 // from "mipi_dsi_priv.h"
 
         typedef struct _mp_lcd_dsi_bus_obj_t {
             mp_obj_base_t base;

--- a/ext_mod/lcd_bus/micropython.cmake
+++ b/ext_mod/lcd_bus/micropython.cmake
@@ -13,6 +13,7 @@ if(ESP_PLATFORM)
     set(LCD_SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/modlcd_bus.c
         ${CMAKE_CURRENT_LIST_DIR}/lcd_types.c
+        ${CMAKE_CURRENT_LIST_DIR}/esp32_src/dsi_bus.c
         ${CMAKE_CURRENT_LIST_DIR}/esp32_src/i2c_bus.c
         ${CMAKE_CURRENT_LIST_DIR}/esp32_src/spi_bus.c
         ${CMAKE_CURRENT_LIST_DIR}/esp32_src/i80_bus.c

--- a/ext_mod/lcd_bus/modlcd_bus.c
+++ b/ext_mod/lcd_bus/modlcd_bus.c
@@ -6,7 +6,9 @@
 #include "i2c_bus.h"
 #include "i80_bus.h"
 #include "rgb_bus.h"
+#ifdef SOC_MIPI_DSI_SUPPORTED
 #include "dsi_bus.h"
+#endif
 
 #ifdef MP_PORT_UNIX
     #include "sdl_bus.h"

--- a/ext_mod/lcd_bus/modlcd_bus.c
+++ b/ext_mod/lcd_bus/modlcd_bus.c
@@ -6,6 +6,7 @@
 #include "i2c_bus.h"
 #include "i80_bus.h"
 #include "rgb_bus.h"
+#include "dsi_bus.h"
 
 #ifdef MP_PORT_UNIX
     #include "sdl_bus.h"
@@ -291,6 +292,9 @@ static const mp_rom_map_elem_t mp_module_lcd_bus_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SPIBus),             MP_ROM_PTR(&mp_lcd_spi_bus_type)        },
     { MP_ROM_QSTR(MP_QSTR_I2CBus),             MP_ROM_PTR(&mp_lcd_i2c_bus_type)        },
     { MP_ROM_QSTR(MP_QSTR_I80Bus),             MP_ROM_PTR(&mp_lcd_i80_bus_type)        },
+    #ifdef SOC_MIPI_DSI_SUPPORTED
+    { MP_ROM_QSTR(MP_QSTR_DSIBus),             MP_ROM_PTR(&mp_lcd_dsi_bus_type)        },
+    #endif
     { MP_ROM_QSTR(MP_QSTR__pump_main_thread),  MP_ROM_PTR(&mp_lcd_bus__pump_main_thread_obj)       },
 
     #ifdef MP_PORT_UNIX


### PR DESCRIPTION
As discussed [here](https://github.com/lvgl-micropython/lvgl_micropython/discussions/497#discussioncomment-15151542), I'm submitting the fixes I made to make the DSI driver work.


### Boards tested

The only ESP32P4 board that I have is WHY2025 badge (https://gitlab.com/why2025/team-badge/Hardware) with st7703-based screen (exact model is W395HDC001-A).
One thing to note is that on this board the screen is powered via one of the channels of ESP32P4 [LDO](https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/peripherals/ldo_regulator.html), which is not currently supported by micropython, however I opened a [PR there](https://github.com/micropython/micropython/pull/18538)

### Code exampled used to test the display


```python
import lcd_bus, st7703, display_driver_framework, lvgl as lv  # NOQA

from esp32 import LDO # LDO support is not yet merged in micropython
ldo = LDO(3, voltage_mv=2500, adjustable=False)

display_bus = lcd_bus.DSIBus(bus_id=0,
                             data_lanes=2,
                             lane_bitrate=1000,
                             clock_freq=47,
                             virtual_channel=0,
                             hsync_back_porch=120,
                             hsync_pulse_width=60,
                             hsync_front_porch=106,
                             vsync_back_porch=20,
                             vsync_pulse_width=4,
                             vsync_front_porch=20
                             )

buf1 = display_bus.allocate_framebuffer(720 * 720 * 2, lcd_bus.MEMORY_SPIRAM)
buf2 = display_bus.allocate_framebuffer(720 * 720 * 2, lcd_bus.MEMORY_SPIRAM)

display = st7703.ST7703(data_bus=display_bus,
                        display_width=720,
                        display_height=720,
                        frame_buffer1=buf1,
                        frame_buffer2=buf2,
                        reset_pin=17,
                        reset_state=st7703.STATE_HIGH,
                        color_space=lv.COLOR_FORMAT.RGB565
                        )
display.init()

scrn = lv.screen_active()

scrn.set_style_bg_color(lv.color_hex(0x00FF00), 0)

label = lv.label(scrn)
label.set_text("HELLO LVGL!")
label.align(lv.ALIGN.CENTER, 0, 0)
label.set_style_text_font(lv.font_montserrat_42, 0)

import task_handler

th = task_handler.TaskHandler()

```
![IMG_3517 Large](https://github.com/user-attachments/assets/68036f56-b2cd-4d82-a8e8-56c20afd81fe)

I can submit another PR with the ST7703 driver, but there's nothing I've implemented except for the custom initialization commands specific to my particular display. Rotation also doesn't work for this display for some reason (I've tried a bunch of different MADCTL commands but it only ever flips at either 90 or 270 degrees).