### PR TITLE
fixes problem with initialization in io_expander ch422g.py

### DIFF
--- a/api_drivers/common_api_drivers/io_expander/ch422g.py
+++ b/api_drivers/common_api_drivers/io_expander/ch422g.py
@@ -33,9 +33,8 @@ class Pin(io_expander_framework.Pin):
 
     @classmethod
     def set_device(cls, device):
-        if cls._device is not None:
-            raise ValueError('device has already been set')
-
+        io_expander_framework.Pin.set_device(device)
+        
         cls._device = device
 
         cls._reg_in = i2c.I2C.Device(


### PR DESCRIPTION
The device should be set in io_expander_framework.py. So it's consistent across all drivers.