### PR TITLE
display_driver_framework.py: reduce backlight PWM frequency

### DIFF
--- a/api_drivers/py_api_drivers/frozen/display/display_driver_framework.py
+++ b/api_drivers/py_api_drivers/frozen/display/display_driver_framework.py
@@ -173,7 +173,7 @@ class DisplayDriver:
                     backlight_on_state = STATE_HIGH
                 else:
                     self._backlight_pin = machine.PWM(
-                        self._backlight_pin, freq=38000)
+                        self._backlight_pin, freq=3800)
 
             if (
                 backlight_on_state != STATE_PWM and


### PR DESCRIPTION
The 38kHz frequency for the display backlight was causing issues on QEMU because QEMU had trouble accurately timing that high of a frequency, causing it to "miss" some of the signal, causing it to never go fully 100% bright.

As the human eye's refresh rate is far lower, and the LilyGo example code I checked uses just 1kHz, I figured 3.8kHz would still be plenty fast.

Presumably, a lower PWM output speed is also good for EMF radiation and power consumption, so why not :-)