### PR TITLE
fix: crash when deinitializing unused timers on unix

### DIFF
--- a/micropy_updates/unix/machine_timer.c
+++ b/micropy_updates/unix/machine_timer.c
@@ -91,7 +91,9 @@ void machine_timer_deinit_all(void)
     pthread_mutex_unlock(&timer_lock);
 
     timer_polling = false;
-    pthread_join(timer_poll_thread_id, NULL);
+    if (timer_poll_thread_id != 0) {
+        pthread_join(timer_poll_thread_id, NULL);
+    }
     pthread_mutex_destroy(&timer_lock);
 
     timer = NULL;


### PR DESCRIPTION
Fix for crash with the unix port when timer thread is being joined on de-initialization even if it's not initialized. 

Fixes #539 .