### PR TITLE
add ST7789V display driver with 0xB4 inversion control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,12 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# PLY generated parser tables
+ext_mod/lvgl/lextab.py
+ext_mod/lvgl/yacctab.py
+
+# Local test files
+main.py
+# Generated stubs
+lvgl.pyi

--- a/api_drivers/common_api_drivers/display/st7789v/_st7789v_init.py
+++ b/api_drivers/common_api_drivers/display/st7789v/_st7789v_init.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2024 - 2025 Kevin G. Schlosser
+
+import time
+from micropython import const  # NOQA
+
+import lvgl as lv  # NOQA
+import lcd_bus
+
+
+_SWRESET = const(0x01)
+_SLPOUT = const(0x11)
+_MADCTL = const(0x36)
+_COLMOD = const(0x3A)
+_PORCTRL = const(0xB2)
+_GCTRL = const(0xB7)
+_VCOMS = const(0xBB)
+_LCMCTRL = const(0xC0)
+_VDVVRHEN = const(0xC2)
+_VRHS = const(0xC3)
+_VDVSET = const(0xC4)
+_FRCTR2 = const(0xC6)
+_PWCTRL1 = const(0xD0)
+_INVCTR = const(0xB4)  # Display Inversion Control (ST7789V)
+_CASET = const(0x2A)
+_RASET = const(0x2B)
+_PGC = const(0xE0)
+_NGC = const(0xE1)
+_DISPON = const(0x29)
+_NORON = const(0x13)
+
+_RAMCTRL = const(0xB0)
+_RGB565SWAP = const(0x08)
+
+
+def init(self):
+    param_buf = bytearray(14)
+    param_mv = memoryview(param_buf)
+
+    self.set_params(_SWRESET)
+
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_SLPOUT)
+
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_NORON)
+
+    param_buf[0] = (
+        self._madctl(
+            self._color_byte_order,
+            self._ORIENTATION_TABLE  # NOQA
+        )
+    )
+    self.set_params(_MADCTL, param_mv[:1])
+
+    param_buf[0] = 0x0A
+    param_buf[1] = 0x82
+    self.set_params(0xB6, param_mv[:2])
+
+    if (
+        self._rgb565_byte_swap and
+        isinstance(self._data_bus, lcd_bus.I80Bus) and
+        self._data_bus.get_lane_count() == 8
+    ):
+        param_buf[0] = 0x00
+        param_buf[1] = 0xF0 | _RGB565SWAP
+        self.set_params(_RAMCTRL, param_mv[:2])
+
+    color_size = lv.color_format_get_size(self._color_space)
+    if color_size == 2:  # NOQA
+        pixel_format = 0x55
+    elif color_size == 3:
+        pixel_format = 0x77
+    else:
+        raise RuntimeError(
+            f'{self.__class__.__name__} IC only supports '
+            'lv.COLOR_FORMAT.RGB565 or lv.COLOR_FORMAT.RGB888'
+        )
+
+    param_buf[0] = pixel_format
+    self.set_params(_COLMOD, param_mv[:1])
+
+    time.sleep_ms(10)  # NOQA
+
+    param_buf[0] = 0x0C
+    param_buf[1] = 0x0C
+    param_buf[2] = 0x00
+    param_buf[3] = 0x33
+    param_buf[4] = 0x33
+    self.set_params(_PORCTRL, param_mv[:5])
+
+    param_buf[0] = 0x35
+    self.set_params(_GCTRL, param_mv[:1])
+
+    param_buf[0] = 0x28
+    self.set_params(_VCOMS, param_mv[:1])
+
+    param_buf[0] = 0x0C
+    self.set_params(_LCMCTRL, param_mv[:1])
+
+    param_buf[0] = 0x01
+    self.set_params(_VDVVRHEN, param_mv[:1])
+
+    param_buf[0] = 0x13
+    self.set_params(_VRHS, param_mv[:1])
+
+    param_buf[0] = 0x20
+    self.set_params(_VDVSET, param_mv[:1])
+
+    param_buf[0] = 0x0F
+    self.set_params(_FRCTR2, param_mv[:1])
+
+    param_buf[0] = 0xA4
+    param_buf[1] = 0xA1
+    self.set_params(_PWCTRL1, param_mv[:2])
+
+    param_buf[0] = 0xD0
+    param_buf[1] = 0x00
+    param_buf[2] = 0x02
+    param_buf[3] = 0x07
+    param_buf[4] = 0x0A
+    param_buf[5] = 0x28
+    param_buf[6] = 0x32
+    param_buf[7] = 0x44
+    param_buf[8] = 0x42
+    param_buf[9] = 0x06
+    param_buf[10] = 0x0E
+    param_buf[11] = 0x12
+    param_buf[12] = 0x14
+    param_buf[13] = 0x17
+    self.set_params(_PGC, param_mv[:14])
+
+    param_buf[0] = 0xD0
+    param_buf[1] = 0x00
+    param_buf[2] = 0x02
+    param_buf[3] = 0x07
+    param_buf[4] = 0x0A
+    param_buf[5] = 0x28
+    param_buf[6] = 0x31
+    param_buf[7] = 0x54
+    param_buf[8] = 0x47
+    param_buf[9] = 0x0E
+    param_buf[10] = 0x1C
+    param_buf[11] = 0x17
+    param_buf[12] = 0x1B
+    param_buf[13] = 0x1E
+    self.set_params(_NGC, param_mv[:14])
+
+    # ST7789V: use 0xB4 with parameter 0x01 for 1-dot inversion
+    param_buf[0] = 0x01
+    self.set_params(_INVCTR, param_mv[:1])
+
+    param_buf[0] = 0x00
+    param_buf[1] = 0x00
+    param_buf[2] = (self.display_width >> 8) & 0xFF
+    param_buf[3] = self.display_width & 0xFF
+
+    self.set_params(_CASET, param_mv[:4])
+
+    # Page addresses
+    param_buf[0] = 0x00
+    param_buf[1] = 0x00
+    param_buf[2] = (self.display_height >> 8) & 0xFF
+    param_buf[3] = self.display_height & 0xFF
+
+    self.set_params(_RASET, param_mv[:4])
+
+    self.set_params(_DISPON)
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_SLPOUT)
+    time.sleep_ms(120)  # NOQA

--- a/api_drivers/common_api_drivers/display/st7789v/st7789v.py
+++ b/api_drivers/common_api_drivers/display/st7789v/st7789v.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2024 - 2025 Kevin G. Schlosser
+
+from micropython import const  # NOQA
+import display_driver_framework
+import lcd_bus
+import lvgl as lv
+
+
+STATE_HIGH = display_driver_framework.STATE_HIGH
+STATE_LOW = display_driver_framework.STATE_LOW
+STATE_PWM = display_driver_framework.STATE_PWM
+
+BYTE_ORDER_RGB = display_driver_framework.BYTE_ORDER_RGB
+BYTE_ORDER_BGR = display_driver_framework.BYTE_ORDER_BGR
+
+_MADCTL_MV = const(0x20)  # 0=Normal, 1=Row/column exchange
+_MADCTL_MX = const(0x40)  # 0=Left to Right, 1=Right to Left
+_MADCTL_MY = const(0x80)  # 0=Top to Bottom, 1=Bottom to Top
+
+_INVCTR = const(0xB4)  # Display Inversion Control (ST7789V)
+
+
+class ST7789V(display_driver_framework.DisplayDriver):
+    _ORIENTATION_TABLE = (
+        0x0,
+        _MADCTL_MV | _MADCTL_MX,
+        _MADCTL_MY | _MADCTL_MX,
+        _MADCTL_MV | _MADCTL_MY
+    )
+
+    # ST7789V uses 0xB4 for inversion control, not 0x20/0x21.
+    # Set these to None so the base set_color_inversion() raises
+    # NotImplementedError rather than sending the wrong commands.
+    _INVON = None
+    _INVOFF = None
+
+    def __init__(
+        self,
+        data_bus,
+        display_width,
+        display_height,
+        frame_buffer1=None,
+        frame_buffer2=None,
+        reset_pin=None,
+        reset_state=STATE_HIGH,
+        power_pin=None,
+        power_on_state=STATE_HIGH,
+        backlight_pin=None,
+        backlight_on_state=STATE_HIGH,
+        offset_x=0,
+        offset_y=0,
+        color_byte_order=BYTE_ORDER_RGB,
+        color_space=lv.COLOR_FORMAT.RGB888,  # NOQA
+        rgb565_byte_swap=False,
+    ):
+
+        if color_space != lv.COLOR_FORMAT.RGB565:  # NOQA
+            rgb565_byte_swap = False
+
+        self._rgb565_byte_swap = rgb565_byte_swap
+
+        if (
+            isinstance(data_bus, lcd_bus.I80Bus) and
+            data_bus.get_lane_count() == 8
+        ):
+            rgb565_byte_swap = False
+
+        super().__init__(
+            data_bus=data_bus,
+            display_width=display_width,
+            display_height=display_height,
+            frame_buffer1=frame_buffer1,
+            frame_buffer2=frame_buffer2,
+            reset_pin=reset_pin,
+            reset_state=reset_state,
+            power_pin=power_pin,
+            power_on_state=power_on_state,
+            backlight_pin=backlight_pin,
+            backlight_on_state=backlight_on_state,
+            offset_x=offset_x,
+            offset_y=offset_y,
+            color_byte_order=color_byte_order,
+            color_space=color_space,  # NOQA
+            rgb565_byte_swap=rgb565_byte_swap,
+            _cmd_bits=8,
+            _param_bits=8,
+            _init_bus=True
+        )
+
+    def set_color_inversion(self, value):
+        # ST7789V uses 0xB4 with parameter:
+        #   bit 0: 0 = normal, 1 = inverted
+        param_buf = bytearray(1)
+        param_mv = memoryview(param_buf)
+        param_buf[0] = 0x01 if value else 0x00
+        self.set_params(_INVCTR, param_mv)

--- a/api_drivers/common_api_drivers/display/st7789v/st7789v.py
+++ b/api_drivers/common_api_drivers/display/st7789v/st7789v.py
@@ -29,10 +29,8 @@ class ST7789V(display_driver_framework.DisplayDriver):
     )
 
     # ST7789V uses 0xB4 for inversion control, not 0x20/0x21.
-    # Set these to None so the base set_color_inversion() raises
-    # NotImplementedError rather than sending the wrong commands.
-    _INVON = None
-    _INVOFF = None
+    _INVON = const(0x01)
+    _INVOFF = const(0x00)
 
     def __init__(
         self,
@@ -90,7 +88,5 @@ class ST7789V(display_driver_framework.DisplayDriver):
     def set_color_inversion(self, value):
         # ST7789V uses 0xB4 with parameter:
         #   bit 0: 0 = normal, 1 = inverted
-        param_buf = bytearray(1)
-        param_mv = memoryview(param_buf)
-        param_buf[0] = 0x01 if value else 0x00
-        self.set_params(_INVCTR, param_mv)
+        self._param_buf[0] = self._INVON if value else self._INVOFF
+        self.set_params(_INVCTR, self._param_mv[:1])

--- a/api_drivers/common_api_drivers/display/st7789v/st7789v.py
+++ b/api_drivers/common_api_drivers/display/st7789v/st7789v.py
@@ -29,8 +29,8 @@ class ST7789V(display_driver_framework.DisplayDriver):
     )
 
     # ST7789V uses 0xB4 for inversion control, not 0x20/0x21.
-    _INVON = const(0x01)
-    _INVOFF = const(0x00)
+    _INVON = 0x01
+    _INVOFF = 0x00
 
     def __init__(
         self,


### PR DESCRIPTION
ST7789V differs from standard ST7789 in the display inversion control mechanism. Instead of using 0x20/0x21 commands, ST7789V uses register 0xB4 with a parameter byte (bit 0: 0=normal, 1=inverted). Using the standard ST7789 driver on ST7789V causes inverted colors.

This driver inherits from DisplayDriver and overrides set_color_inversion() to use the correct 0xB4 register.