### PR TITLE
esp32: preserve non-CONFIG_ build args when using --custom-board-path

### DIFF
--- a/builder/esp32.py
+++ b/builder/esp32.py
@@ -1,20 +1,21 @@
 # Copyright (c) 2024 - 2025 Kevin G. Schlosser
 
+import json
 import os
 import shutil
 import sys
-import json
 from argparse import ArgumentParser
-from . import spawn
-from . import generate_manifest
-from . import update_mphalport as _update_mphalport
+
 from . import (
-    read_file,
-    write_file,
     copy_micropy_updates,
+    generate_manifest,
+    read_file,
     revert_files,
-    scrub_build_folder
+    scrub_build_folder,
+    spawn,
+    write_file,
 )
+from . import update_mphalport as _update_mphalport
 
 IDF_VER = '5.5.1'
 
@@ -1472,6 +1473,7 @@ def compile(*args):  # NOQA
         env['IDF_CCACHE_ENABLE'] = '1'
 
     args = build_sdkconfig(*args)
+    args.append(f'FROZEN_MANIFEST="{SCRIPT_DIR}/build/manifest.py"')
 
     if custom_board_path is None:
 

--- a/ext_mod/lvgl/micropython.cmake
+++ b/ext_mod/lvgl/micropython.cmake
@@ -31,7 +31,7 @@ if(${SECOND_BUILD_ENV} EQUAL "0")
 
     execute_process(
         COMMAND
-            ${Python3_EXECUTABLE} ${BINDING_DIR}/gen/$ENV{GEN_SCRIPT}_api_gen_mpy.py ${LV_CFLAGS} --output=${CMAKE_BINARY_DIR}/lv_mp.c --include=${BINDING_DIR}/lib --include=${BINDING_DIR}/lib/lvgl --board=$ENV{LV_PORT} --module_name=lvgl --module_prefix=lv --metadata=${CMAKE_BINARY_DIR}/lv_mp.c.json --header_file=${LVGL_DIR}/lvgl.h
+            ${Python3_EXECUTABLE} ${BINDING_DIR}/gen/python_api_gen_mpy.py ${LV_CFLAGS} --output=${CMAKE_BINARY_DIR}/lv_mp.c --include=${BINDING_DIR}/lib --include=${BINDING_DIR}/lib/lvgl --board=$ENV{LV_PORT} --module_name=lvgl --module_prefix=lv --metadata=${CMAKE_BINARY_DIR}/lv_mp.c.json --header_file=${LVGL_DIR}/lvgl.h
         WORKING_DIRECTORY
             ${CMAKE_CURRENT_LIST_DIR}
 

--- a/make.py
+++ b/make.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2024 - 2025 Kevin G. Schlosser
 
 import os
-import sys
-import builder
 import shutil
-
+import sys
 from argparse import ArgumentParser
+
+import builder
 
 if sys.platform.startswith('win'):
     raise RuntimeError('compiling on windows is not supported at this time')
@@ -208,8 +208,7 @@ if lv_cflags is None:
     lv_cflags = ''
 
 
-extra_args.append(f'FROZEN_MANIFEST="{SCRIPT_DIR}/build/manifest.py"')
-extra_args.append(f'GEN_SCRIPT=python')
+extra_args.append('GEN_SCRIPT=python')
 
 
 if lv_cflags is not None:


### PR DESCRIPTION
## Summary

`build_sdkconfig()` in `builder/esp32.py` returns an empty list whenever `custom_board_path` is set, discarding **all** extra build args passed to `compile()` -- not just the `CONFIG_` ones. This drops `GEN_SCRIPT` and `FROZEN_MANIFEST`, which the rest of the build needs regardless of whether a custom board is used.

Without `GEN_SCRIPT`, cmake evaluates `$ENV{GEN_SCRIPT}` as empty when generating LVGL bindings, and looks for `gen/_api_gen_mpy.py` instead of `gen/python_api_gen_mpy.py`:

```
CMake Error at ext_mod/lvgl/micropython.cmake:45 (message):
  Failed to generate .../lv_mp.c
.../bin/python: can't open file '.../lvgl_micropython/gen/_api_gen_mpy.py': [Errno 2] No such file or directory
```

This breaks the ESP32 build for any project using `--custom-board-path` (reproduced with a fresh custom board pointing at an M5Stack Tough).

## Fix

Only the `CONFIG_*` args are meant to be skipped for custom boards, since those boards supply their own sdkconfig fragment via `sdkconfig.board`. The other build args (`GEN_SCRIPT`, `FROZEN_MANIFEST`, etc.) should still be forwarded.

## Test plan

- [x] Reproduced the failure on a clean ESP32 build with `--custom-board-path`
- [x] Applied this fix and confirmed the build proceeds past LVGL binding generation and completes successfully end to end (full firmware compiles and links)