### PR TITLE
Update mpconfigboard.cmake

### DIFF
--- a/display_configs/LilyGo-TDeck/mpconfigboard.cmake
+++ b/display_configs/LilyGo-TDeck/mpconfigboard.cmake
@@ -3,7 +3,6 @@ set(IDF_TARGET esp32s3)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     ${SDKCONFIG_IDF_VERSION_SPECIFIC}
-    boards/sdkconfig.usb
     boards/sdkconfig.ble
     boards/sdkconfig.spiram_sx
     boards/sdkconfig.spiram_oct


### PR DESCRIPTION
this and #590 fixes the issue with building  custom board config for Lilygo T-Deck
https://github.com/orgs/micropython/discussions/19450#discussioncomment-17591210